### PR TITLE
Use static GUID for workbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ All the reports in this repo are based on [Azure Monitor Workbooks](https://docs
 
 ### Deploy workbooks via ARM template
 
-| Name      | Deploy |
-| ----------- | ----------- |
-| Authentications Workbook      |<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FauthenticationsWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
-| MFA Overview and MFA Failures Workbook      |<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FmfaWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
-| User Behaviour Workbook      |<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FuserBehaviourWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
-| Risk Detection Workbook      |<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FriskDetectionWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
-| Conditional Access Workbook      |<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FconditionalAccessWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
+| Name      | Workbook Id | Deploy |
+| --------- | ------------| ------ |
+| Authentications Workbook      |d284045e-b1c1-4d82-a8b8-b1a59a98eb33|<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FauthenticationsWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
+| MFA Overview and MFA Failures Workbook      |f405c652-7c08-47b9-8005-dc33ae331748|<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FmfaWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
+| User Behaviour Workbook      |65bf1d28-2dc8-4099-8cb1-e3f4a2f32256|<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FuserBehaviourWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
+| Risk Detection Workbook      |0d8084bd-cc7d-4670-988a-ee9553a19fa2|<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FriskDetectionWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
+| Conditional Access Workbook      |a9f52ac8-7a5d-4f86-86b8-092a74410758|<a href=https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fexternal-id-azure-monitor%2Fmain%2Ftemplates%2FconditionalAccessWorkbookDeployment.json data-linktype="external"><img src=https://aka.ms/deploytoazurebutton alt="Deploy to Azure" data-linktype="external"></a>    |
 
 ## Contributing
 

--- a/templates/authenticationsWorkbookDeployment.json
+++ b/templates/authenticationsWorkbookDeployment.json
@@ -1,5 +1,5 @@
 {
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "2.0.0.0",
     "parameters": {
         "workbookDisplayName": {
             "type": "string",
@@ -14,18 +14,11 @@
             "metadata": {
                 "description": "The name of workspace where this workbook will be deployed"
             }
-        },
-        "workbookId": {
-            "type": "string",
-            "defaultValue": "[newGuid()]",
-            "metadata": {
-                "description": "The unique guid for this workbook instance"
-            }
         }
     },
     "resources": [
         {
-            "name": "[parameters('workbookId')]",
+            "name": "d284045e-b1c1-4d82-a8b8-b1a59a98eb33",
             "type": "microsoft.insights/workbooks",
             "location": "[resourceGroup().location]",
             "apiVersion": "2018-06-17-preview",
@@ -43,7 +36,7 @@
     "outputs": {
         "workbookId": {
             "type": "string",
-            "value": "[resourceId( 'microsoft.insights/workbooks', parameters('workbookId'))]"
+            "value": "[resourceId( 'microsoft.insights/workbooks', 'd284045e-b1c1-4d82-a8b8-b1a59a98eb33')]"
         }
     },
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"

--- a/templates/conditionalAccessWorkbookDeployment.json
+++ b/templates/conditionalAccessWorkbookDeployment.json
@@ -1,5 +1,5 @@
 {
-  "contentVersion": "1.0.0.0",
+  "contentVersion": "2.0.0.0",
   "parameters": {
     "workbookDisplayName": {
       "type": "string",
@@ -14,18 +14,11 @@
       "metadata": {
         "description": "The name of workspace where this workbook will be deployed"
       }
-    },
-    "workbookId": {
-      "type": "string",
-      "defaultValue": "[newGuid()]",
-      "metadata": {
-        "description": "The unique guid for this workbook instance"
-      }
     }
   },
   "resources": [
     {
-      "name": "[parameters('workbookId')]",
+      "name": "a9f52ac8-7a5d-4f86-86b8-092a74410758",
       "type": "microsoft.insights/workbooks",
       "location": "[resourceGroup().location]",
       "kind": "shared",
@@ -43,7 +36,7 @@
   "outputs": {
     "workbookId": {
       "type": "string",
-      "value": "[resourceId( 'Microsoft.Insights/workbooks', parameters('workbookId'))]"
+      "value": "[resourceId( 'Microsoft.Insights/workbooks', 'a9f52ac8-7a5d-4f86-86b8-092a74410758')]"
     }
   },
   "$schema": "http://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"

--- a/templates/mfaWorkbookDeployment.json
+++ b/templates/mfaWorkbookDeployment.json
@@ -1,5 +1,5 @@
 {
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "2.0.0.0",
     "parameters": {
         "workbookDisplayName": {
             "type": "string",
@@ -14,18 +14,11 @@
             "metadata": {
                 "description": "The name of workspace where this workbook will be deployed"
             }
-        },
-        "workbookId": {
-            "type": "string",
-            "defaultValue": "[newGuid()]",
-            "metadata": {
-                "description": "The unique guid for this workbook instance"
-            }
         }
     },
     "resources": [
         {
-            "name": "[parameters('workbookId')]",
+            "name": "f405c652-7c08-47b9-8005-dc33ae331748",
             "type": "microsoft.insights/workbooks",
             "location": "[resourceGroup().location]",
             "apiVersion": "2018-06-17-preview",
@@ -43,7 +36,7 @@
     "outputs": {
         "workbookId": {
             "type": "string",
-            "value": "[resourceId( 'microsoft.insights/workbooks', parameters('workbookId'))]"
+            "value": "[resourceId('microsoft.insights/workbooks', 'f405c652-7c08-47b9-8005-dc33ae331748')]"
         }
     },
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"

--- a/templates/riskDetectionWorkbookDeployment.json
+++ b/templates/riskDetectionWorkbookDeployment.json
@@ -1,5 +1,5 @@
 {
-  "contentVersion": "1.0.0.0",
+  "contentVersion": "2.0.0.0",
   "parameters": {
     "workbookDisplayName": {
       "type": "string",
@@ -14,18 +14,11 @@
       "metadata": {
         "description": "The name of workspace where this workbook will be deployed"
       }
-    },
-    "workbookId": {
-      "type": "string",
-      "defaultValue": "[newGuid()]",
-      "metadata": {
-        "description": "The unique guid for this workbook instance"
-      }
     }
   },
   "resources": [
     {
-      "name": "[parameters('workbookId')]",
+      "name": "0d8084bd-cc7d-4670-988a-ee9553a19fa2",
       "type": "microsoft.insights/workbooks",
       "location": "[resourceGroup().location]",
       "kind": "shared",
@@ -43,7 +36,7 @@
   "outputs": {
     "workbookId": {
       "type": "string",
-      "value": "[resourceId( 'Microsoft.Insights/workbooks', parameters('workbookId'))]"
+      "value": "[resourceId( 'Microsoft.Insights/workbooks', '0d8084bd-cc7d-4670-988a-ee9553a19fa2')]"
     }
   },
   "$schema": "http://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"

--- a/templates/userBehaviourWorkbookDeployment.json
+++ b/templates/userBehaviourWorkbookDeployment.json
@@ -1,5 +1,5 @@
 {
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "2.0.0.0",
     "parameters": {
         "workbookDisplayName": {
             "type": "string",
@@ -14,18 +14,11 @@
             "metadata": {
                 "description": "The name of workspace where this workbook will be deployed"
             }
-        },
-        "workbookId": {
-            "type": "string",
-            "defaultValue": "[newGuid()]",
-            "metadata": {
-                "description": "The unique guid for this workbook instance"
-            }
         }
     },
     "resources": [
         {
-            "name": "[parameters('workbookId')]",
+            "name": "65bf1d28-2dc8-4099-8cb1-e3f4a2f32256",
             "type": "Microsoft.Insights/workbooks",
             "location": "[resourceGroup().location]",
             "kind": "shared",
@@ -43,7 +36,7 @@
     "outputs": {
         "workbookId": {
             "type": "string",
-            "value": "[resourceId( 'Microsoft.Insights/workbooks', parameters('workbookId'))]"
+            "value": "[resourceId('Microsoft.Insights/workbooks', '65bf1d28-2dc8-4099-8cb1-e3f4a2f32256')]"
         }
     },
     "$schema": "http://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"


### PR DESCRIPTION
Currently, we're autogenerating a new workbook id on every install, making it hard to track the workbooks coming from our templates. 
Updating a workbook is also not possible when a new update is available.
This change adds static workbook ids to ensure final id is predictable.